### PR TITLE
Update git organizations to forge-42

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 # react-router-devtools
 
-![GitHub Repo stars](https://img.shields.io/github/stars/forge42dev/react-router-devtools?style=social)
+![GitHub Repo stars](https://img.shields.io/github/stars/forge-42/react-router-devtools?style=social)
 ![npm](https://img.shields.io/npm/v/react-router-devtools?style=plastic)
-![GitHub](https://img.shields.io/github/license/forge42dev/react-router-devtools?style=plastic)
+![GitHub](https://img.shields.io/github/license/forge-42/react-router-devtools?style=plastic)
 ![npm](https://img.shields.io/npm/dy/react-router-devtools?style=plastic)
 ![npm](https://img.shields.io/npm/dw/react-router-devtools?style=plastic)
-![GitHub top language](https://img.shields.io/github/languages/top/forge42dev/react-router-devtools?style=plastic)
+![GitHub top language](https://img.shields.io/github/languages/top/forge-42/react-router-devtools?style=plastic)
 
 react-router-devtools is an open-source package designed to enhance your development workflow when working with React Router v7+, a full-stack JavaScript framework for building web applications. This package provides a user-friendly interface consisting of three tabs, **Active Page**, **Terminal**, **Settings**, **Errors**, **Network** and **Routes**, along with a side tab called **Timeline**. With react-router-devtools, you can efficiently monitor and manage various aspects of your React Router v7+ projects, including page information, URL parameters, server responses, loader data, routes, and more.
 
@@ -23,7 +23,7 @@ You can also track down hydration issues with the **Errors** tab and view your r
 
 This repository used to be called remix-development-tools, but we decided to rename it to react-router-devtools to better reflect the fact that it's a package for React Router v7+ and not just for Remix.
 
-If you're looking for the old version of this package, you can find it [here](https://github.com/forge42dev/Remix-Dev-Tools/tree/remix-development-tools).
+If you're looking for the old version of this package, you can find it [here](https://github.com/forge-42/react-router-devtools/tree/remix-development-tools).
 
 And the detailed documentation can be found [here](https://remix-development-tools.fly.dev/).
 

--- a/docs/app/components/layout/Header.tsx
+++ b/docs/app/components/layout/Header.tsx
@@ -394,7 +394,7 @@ export default function Header({
                     <a
                       className="group"
                       aria-label="GitHub"
-                      href="https://github.com/forge42dev/react-router-devtools"
+                      href="https://github.com/forge-42/react-router-devtools"
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/docs/app/components/ui/navbar-menu.tsx
+++ b/docs/app/components/ui/navbar-menu.tsx
@@ -119,7 +119,7 @@ export function Navbar({ className }: { className?: string }) {
           <div className="flex flex-col space-y-4 text-sm">
             <ExternalLink url="https://reactrouter.com/en/main" text="React Router" />
             <ExternalLink
-              url="https://github.com/forge42dev/react-router-devtools"
+              url="https://github.com/forge-42/react-router-devtools"
               text="Github"
             />
             <ExternalLink

--- a/package.json
+++ b/package.json
@@ -63,13 +63,13 @@
 	"files": ["dist"],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/forge42dev/react-router-devtools.git"
+		"url": "git+https://github.com/forge-42/react-router-devtools.git"
 	},
 	"bugs": {
-		"url": "https://github.com/forge42dev/react-router-devtools/issues"
+		"url": "https://github.com/forge-42/react-router-devtools/issues"
 	},
 	"homepage": "https://react-router-devtools.forge42.dev/",
-	"readme": "https://github.com/forge42dev/react-router-devtools#readme",
+	"readme": "https://github.com/forge-42/react-router-devtools#readme",
 	"scripts": {
 		"clean": "git clean -fdX --exclude=\"!.env\"",
 		"docs": "npm run dev -w docs",


### PR DESCRIPTION
# Description

This patch changes a few git links to the `forge-42` organization.

Fixes # (issue)

N/A.

## Type of change

Please delete options that are not relevant.

- [x] Minor fix unrelated to the code.

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings or errors
