### PR TITLE
fix: babel security advisory GHSA-968p-4wvh-cqc8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "react-router-devtools",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "react-router-devtools",
-			"version": "1.1.7",
+			"version": "1.1.8",
 			"license": "MIT",
 			"workspaces": [
 				".",
 				"test-apps/*"
 			],
 			"dependencies": {
-				"@babel/core": "^7.26.7",
+				"@babel/core": "^7.26.10",
 				"@babel/generator": "^7.26.5",
-				"@babel/parser": "^7.26.7",
-				"@babel/traverse": "^7.26.7",
-				"@babel/types": "^7.26.7",
+				"@babel/parser": "^7.26.10",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"@radix-ui/react-accordion": "^1.2.2",
 				"@radix-ui/react-select": "^2.1.5",
 				"beautify": "^0.0.8",
@@ -122,20 +122,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-			"integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+			"integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.5",
+				"@babel/generator": "^7.26.10",
 				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helpers": "^7.26.7",
-				"@babel/parser": "^7.26.7",
-				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.26.7",
-				"@babel/types": "^7.26.7",
+				"@babel/helpers": "^7.26.10",
+				"@babel/parser": "^7.26.10",
+				"@babel/template": "^7.26.9",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -151,12 +152,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-			"integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+			"integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.5",
-				"@babel/types": "^7.26.5",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -323,23 +325,25 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-			"integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+			"integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.7"
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-			"integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.7"
+				"@babel/types": "^7.27.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -453,28 +457,30 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.9",
-				"@babel/parser": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-			"integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+			"integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.5",
-				"@babel/parser": "^7.26.7",
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.7",
+				"@babel/generator": "^7.27.0",
+				"@babel/parser": "^7.27.0",
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -483,9 +489,10 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-			"integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.25.9",
 				"@babel/helper-validator-identifier": "^7.25.9"

--- a/package.json
+++ b/package.json
@@ -142,11 +142,11 @@
 		"vitest": "^3.0.4"
 	},
 	"dependencies": {
-		"@babel/core": "^7.26.7",
+		"@babel/core": "^7.26.10",
 		"@babel/generator": "^7.26.5",
-		"@babel/parser": "^7.26.7",
-		"@babel/traverse": "^7.26.7",
-		"@babel/types": "^7.26.7",
+		"@babel/parser": "^7.26.10",
+		"@babel/traverse": "^7.26.10",
+		"@babel/types": "^7.26.10",
 		"@radix-ui/react-accordion": "^1.2.2",
 		"@radix-ui/react-select": "^2.1.5",
 		"beautify": "^0.0.8",


### PR DESCRIPTION
This patch updates babel to fix a security issue, currently preventing dependabot from fixing it.

Details at https://github.com/advisories/GHSA-968p-4wvh-cqc8.