### PR TITLE
Added additional support to wrapping the default export specifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-router-devtools",
 	"description": "Devtools for React Router - debug, trace, find hydration errors, catch bugs and inspect server/client data with react-router-devtools",
 	"author": "Alem Tuzlak",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"license": "MIT",
 	"keywords": [
 		"react-router",

--- a/src/vite/utils/inject-client.test.ts
+++ b/src/vite/utils/inject-client.test.ts
@@ -160,7 +160,7 @@ describe("transform", () => {
 		expect(removeWhitespace(result.code)).toStrictEqual(expected)
 	})
 
-	it("should wrap the default export properly even if it's declared as a variable and then exported via export { name as default }", () => {
+	it("should wrap the default export properly even if it's declared as a variable and then exported via export { name as default } and has other exports as well", () => {
 		const result = injectRdtClient(
 			`
 				import { test } from "./file/path";

--- a/src/vite/utils/inject-client.test.ts
+++ b/src/vite/utils/inject-client.test.ts
@@ -137,6 +137,56 @@ describe("transform", () => {
 		expect(removeWhitespace(result.code)).toStrictEqual(expected)
 	})
 
+	it("should wrap the default export properly even if it's declared as a variable and then exported via export { name as default }", () => {
+		const result = injectRdtClient(
+			`
+			const App = () => {};
+			export { App as default };
+			`,
+			'{ "config": { }, "plugins": "[]" }',
+			"",
+			"/file/path"
+		)
+		const expected = removeWhitespace(`
+			import { withViteDevTools as _withViteDevTools } from "react-router-devtools/client";
+			import rdtStylesheet from "react-router-devtools/client.css?url";
+			const App = () => {};
+			export default _withViteDevTools(App, {
+			config: { },
+				plugins: []
+			});
+			export const links = () => [{ rel: "stylesheet", href: rdtStylesheet }];
+	 `)
+		expect(removeWhitespace(result.code)).toStrictEqual(expected)
+	})
+
+	it("should wrap the default export properly even if it's declared as a variable and then exported via export { name as default }", () => {
+		const result = injectRdtClient(
+			`
+				import { test } from "./file/path";
+			const App = () => {};
+			export { App as default, test };
+			`,
+			'{ "config": { }, "plugins": "[]" }',
+			"",
+			"/file/path"
+		)
+		const expected = removeWhitespace(`
+			import { withViteDevTools as _withViteDevTools } from "react-router-devtools/client";
+			import rdtStylesheet from "react-router-devtools/client.css?url";
+			import { test } from "./file/path";
+			const App = () => {};
+			export default _withViteDevTools(App, {
+			config: { },
+				plugins: []
+			});
+			export { test };
+			export const links = () => [{ rel: "stylesheet", href: rdtStylesheet }];
+
+	 `)
+		expect(removeWhitespace(result.code)).toStrictEqual(expected)
+	})
+
 	it("should wrap the default export properly even if it's declared as a function and then exported", () => {
 		const result = injectRdtClient(
 			`

--- a/test-apps/react-router-vite/app/root.tsx
+++ b/test-apps/react-router-vite/app/root.tsx
@@ -42,7 +42,7 @@ export const action =async  ({devTools}: ActionFunctionArgs) => {
   return  ({ message: "Hello World", bigInt: BigInt(10) });
 }
 
-export default function App() {
+function App() {
   return (
     <html lang="en">
       <head>
@@ -66,3 +66,5 @@ export default function App() {
     </html>
   );
 }
+
+export { App as default }


### PR DESCRIPTION
# Description

Fixes the case where the default export from root was exported as: ` export { App as default }`

Fixes #198

If this is a new feature please add a description of what was added and why below:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests

# Checklist:

- [ ] My code follows the guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
