### PR TITLE
Respect custom appDir for route config

### DIFF
--- a/src/vite/file.ts
+++ b/src/vite/file.ts
@@ -18,6 +18,7 @@ export type WriteFileData = {
 		meta: boolean
 		links: boolean
 	}
+	appDir: string
 }
 const defaultGenerationOrder: Exclude<Generator, "dependencies">[] = [
 	"links",
@@ -32,7 +33,7 @@ const defaultGenerationOrder: Exclude<Generator, "dependencies">[] = [
 	"errorBoundary",
 	"revalidate",
 ]
-export const handleWriteFile = async ({ path, options, openInEditor }: WriteFileData) => {
+export const handleWriteFile = async ({ path, options, openInEditor, appDir }: WriteFileData) => {
 	const generatorOptions = Object.entries(options)
 		.map(([key, value]) => {
 			if (value) {
@@ -40,7 +41,7 @@ export const handleWriteFile = async ({ path, options, openInEditor }: WriteFile
 			}
 		})
 		.filter(Boolean) as unknown as { key: Exclude<Generator, "dependencies"> }[]
-	let outputFile = `${resolve("app", "routes", path)}`
+	let outputFile = `${resolve(appDir, "routes", path)}`
 	const extensions = [".tsx", ".jsx", ".ts", ".js"]
 	if (!extensions.some((ext) => outputFile.endsWith(ext))) {
 		outputFile = `${outputFile}.tsx`

--- a/src/vite/plugin.tsx
+++ b/src/vite/plugin.tsx
@@ -106,7 +106,7 @@ export const reactRouterDevTools: (args?: ReactRouterViteConfig) => Plugin[] = (
 				try {
 					const path = await import("node:path")
 					// Set the route config
-					const routeConfigExport = (await runner.executeFile(path.join(process.cwd(), "./app/routes.ts"))).default
+					const routeConfigExport = (await runner.executeFile(path.join(process.cwd(), appDir, "routes.ts"))).default
 					const routeConfig = await routeConfigExport
 					routes = routeConfig
 
@@ -338,7 +338,7 @@ export const reactRouterDevTools: (args?: ReactRouterViteConfig) => Plugin[] = (
 					})
 
 					server.hot.on("open-source", (data: OpenSourceData) => handleOpenSource({ data, openInEditor, appDir }))
-					server.hot.on("add-route", (data: WriteFileData) => handleWriteFile({ ...data, openInEditor }))
+					server.hot.on("add-route", (data: WriteFileData) => handleWriteFile({ ...data, openInEditor, appDir }))
 				}
 			},
 		},


### PR DESCRIPTION
# Description

The plugin now correctly respects the configured appDir instead of assuming the default ./app. This ensures route discovery and “open in editor” features work when users place their app in a custom directory.

Fixes # (issue)

Replaced hardcoded `"./app/routes.ts"` with `appDir, "routes.ts")`
Passed `appDir` through to route generation flows:
`handleWriteFile({ ..., appDir })`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual verification:
 - Configured the plugin with a custom app dir in vite.config.ts:
`reactRouterDevTools({ appDir: "./src/app" })`
 - Ensured src/app/root.tsx and src/app/routes/test.tsx exist and defined routes.
 - Routes appear in the devtools Routes panel.
“Add route” generates a file under ./src/app/routes/... and opens it in the editor.

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
